### PR TITLE
Fix for "Yellow" items not included

### DIFF
--- a/randomize.py
+++ b/randomize.py
@@ -28,11 +28,11 @@ results = []
 
 for dirpath, dirnames, filenames in os.walk('recipes'):
 	for filename in filenames:
-		file_list.append(os.path.join(dirpath, filename))
 		with open(os.path.join(dirpath, filename)) as file:
 			res = json.loads(file.read())
 			if "result" in res:
 				results.append(res["result"])
+				file_list.append(os.path.join(dirpath, filename))
 
 
 file_dict = {}


### PR DESCRIPTION
As there are more files than "results" the randomizer runs out of files before it has processed the last few files. This tweak ignores files with no result so the yellow items get included.

The results which are skipped are:
{'type': 'minecraft:crafting_special_armordye'}
{'type': 'minecraft:crafting_special_bannerduplicate'}
{'type': 'minecraft:crafting_special_bookcloning'}
{'type': 'minecraft:crafting_special_firework_rocket'}
{'type': 'minecraft:crafting_special_firework_star'}
{'type': 'minecraft:crafting_special_firework_star_fade'}
{'type': 'minecraft:crafting_special_mapcloning'}
{'type': 'minecraft:crafting_special_mapextending'}
{'type': 'minecraft:crafting_special_repairitem'}
{'type': 'minecraft:crafting_special_shielddecoration'}
{'type': 'minecraft:crafting_special_shulkerboxcoloring'}
{'type': 'minecraft:crafting_special_suspiciousstew'}
{'type': 'minecraft:crafting_special_tippedarrow'}